### PR TITLE
include dict.cc entries with subject labels

### DIFF
--- a/src/com/hughes/android/dictionary/parser/DictFileParser.java
+++ b/src/com/hughes/android/dictionary/parser/DictFileParser.java
@@ -110,9 +110,8 @@ public class DictFileParser implements Parser {
             return;
         }
         final String[] fields = fieldSplit.split(line);
-        // dictcc now has a part of speech field as field #3.
-        if (fields.length < 2 || fields.length > 3) {
-            logger.warning("Malformed line: " + line);
+        if (fields.length < 2 || fields.length > 4) {
+            logger.warning("Malformed line, expected 3 or 4 fields, got " + fields.length + ": " + line);
             return;
         }
 


### PR DESCRIPTION
I used this script to turn a DE-ES dict.cc file into a quickdic compatible with my Tolino. From the original 45k entries more than 20k were dropped because they had a subject label:

> WARNING: Malformed line: Atomphysik {f} física {f} atómica noun [phys.]

This change allows lines to have 4 fields/columns: `language1`, `language2`, `word class`,  `subject labels`.

<img width="681" alt="Bildschirmfoto 2020-12-20 um 02 08 06" src="https://user-images.githubusercontent.com/2032443/102702940-c095b200-4268-11eb-9ea5-b27ff97172d2.png">

see also https://github.com/natowi/quickdic-dictionary.dictionarypc/issues/1